### PR TITLE
Avoid deprecation warning in ansible 2.8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,11 +33,13 @@
     name: yum-cron
     state: started
     enabled: yes
-  when: yum_cron_service_enabled
+  when:
+    - yum_cron_service_enabled == True
 
 - name: Stop yum-cron service and disable at boot time
   service:
     name: yum-cron
     state: stopped
     enabled: no
-  when: not yum_cron_service_enabled
+  when:
+    - yum_cron_service_enabled == False


### PR DESCRIPTION
[DEPRECATION WARNING]: evaluating yum_cron_service_enabled as a bare
variable, this behaviour will go away and you might need to add |bool to
the expression in the future. Also see CONDITIONAL_BARE_VARS
configuration toggle.. This feature will be removed in version 2.12.
Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.